### PR TITLE
Update README to set GOPATH before installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ sudo apt install gcc
 go install github.com/g0ldencybersec/CloudRecon@latest
 ```
 
+Note:
+Don't forget to [set your `GOPATH`](https://github.com/golang/go/wiki/SettingGOPATH) before installing.
+
 # Description
 **CloudRecon** 
 


### PR DESCRIPTION
So that, once user install from github, the GOPATH already set.

Background:
For someone who new in Go, they might haven't set GOPATH yet and can't find where `CloudRecon` is installed or can be executed.