### PR TITLE
Scrape in JSON Output Format & IP:PORT File Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ Store - a tool to retrieve IPs certs and download all their Orgs, CNs, and SANs.
 Retr - a tool to parse and search through the downloaded certs for keywords.
 
 # Usage
+
+## Get Started
+```
+## Don't forget to run in TMUX / Screen session
+wget https://github.com/lord-alfred/ipranges/blob/main/all/ipv4_merged.txt
+CloudRecon scrape -i ipv4_merged.txt -j | tee -a certdb.json
+```
+
+cloudrecon scrape - Scrape given IPs and output CNs & SANs to stdout
+Input Support: Either IPs & CIDRs separated by commas, or a file with IPs/CIDRs on each line, or file contains ip:port format list. 
+
 **MAIN**
 ```sh
 Usage: CloudRecon scrape|store|retr [options]
@@ -78,7 +89,8 @@ scrape [options] -i <IPs/CIDRs or File>
         How many goroutines running concurrently (default 100)
   -h    print usage!
   -i string
-        Either IPs & CIDRs separated by commas, or a file with IPs/CIDRs on each line (default "NONE"                                                                                                                         )
+        Either IPs & CIDRs separated by commas, or a file with IPs/CIDRs on each line (default "NONE")
+  -j    Generate JSON output ("IP, PORT, Organization, CommonName, SAN")
   -p string
         TLS ports to check for certificates (default "443")
   -t int
@@ -120,3 +132,4 @@ retr [options]
   -san string
         String to search for in common name column, returns like-results (default "NONE")
 ```
+

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ wget https://github.com/lord-alfred/ipranges/blob/main/all/ipv4_merged.txt
 CloudRecon scrape -i ipv4_merged.txt -j | tee -a certdb.json
 ```
 
-cloudrecon scrape - Scrape given IPs and output CNs & SANs to stdout
 Input Support: Either IPs & CIDRs separated by commas, or a file with IPs/CIDRs on each line, or file contains ip:port format list. 
 
 **MAIN**
@@ -106,7 +105,7 @@ store [options] -i <IPs/CIDRs or File>
         String of the DB you want to connect to and save certs! (default "certificates.db")
   -h    print usage!
   -i string
-        Either IPs & CIDRs separated by commas, or a file with IPs/CIDRs on each line (default "NONE")
+        Either IPs & CIDRs separated by commas, or a file with IPs/CIDRs on each line, or file contains ip:port format list. (default "NONE")
   -p string
         TLS ports to check for certificates (default "443")
   -t int

--- a/utils.go
+++ b/utils.go
@@ -88,8 +88,7 @@ func isHostPort(value string) bool {
 
 func processInput(argItem string, chanInput chan string, ports []string) {
 	argItem = strings.TrimSpace(argItem)
-	if strings.Contains(argItem, ":") {
-		// If it contains a colon, treat it as IP:port combination
+	if isHostPort(argItem) {
 		chanInput <- argItem
 	} else if isCIDR(argItem) {
 		err := IPsFromCIDR(argItem, chanInput, ports)
@@ -97,7 +96,6 @@ func processInput(argItem string, chanInput chan string, ports []string) {
 			panic("unable to parse CIDR" + argItem)
 		}
 	} else {
-		// Feed atomic host to input channel
 		for _, port := range ports {
 			chanInput <- argItem + ":" + port
 		}

--- a/utils.go
+++ b/utils.go
@@ -56,7 +56,6 @@ func extractNames(cert *x509.Certificate) []string {
 
 func intakeFunction(chanInput chan string, ports []string, input string) {
 	if _, err := os.Stat(input); err == nil {
-		fmt.Printf("Scraping certs for IPs / CIDRs in file %s\n\n", input)
 		readFile, err := os.Open(input)
 		if err != nil {
 			fmt.Println(err)


### PR DESCRIPTION
Added JSON output format in scrape module (`-j`)
JSON output shows, `IP:Port, Organization, CommonName and SAN`
Default scrape output not changed, it is as it is.
Added input support format for IP:PORT file.