### PR TITLE
Fixed URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Retr - a tool to parse and search through the downloaded certs for keywords.
 ## Get Started
 ```
 ## Don't forget to run in TMUX / Screen session
-wget https://github.com/lord-alfred/ipranges/blob/main/all/ipv4_merged.txt
+wget https://raw.githubusercontent.com/lord-alfred/ipranges/main/all/ipv4_merged.txt
 CloudRecon scrape -i ipv4_merged.txt -j | tee -a certdb.json
 ```
 


### PR DESCRIPTION
**Summary**
When I was following the docs, I tried to wget the previous link. That link does not get the raw content. As such, the downloaded file is not the format that CloudRecon expects. So when I ran the example command 
`CloudRecon scrape -i ipv4_merged.txt -j | tee -a certdb.json`
it would run for one second and then exit with nothing printed to the terminal.

After troubleshooting, I realized that the format of the file I was retrieving was the issue. Once I did wget with the raw file the program started working.

One more thing: Despite me adding the `-a` flag, CloudRecon returned no output when it was the parsing file in the wrong format. An error message there would be very useful and could save people time in the future.

That's it. Very minor fix. Ty for all your hard work on this tool, its awesome! 